### PR TITLE
Fix: Address multiple failing tests

### DIFF
--- a/game/plants/base_plant.py
+++ b/game/plants/base_plant.py
@@ -43,18 +43,18 @@ class Plant:
             is_alive=True
         )
     
-    def update(self) -> None:
+    def update(self, dt: float) -> None:
         """
         Update the plant's state for this time step.
         
         Args:
-            None
+            dt: Time delta since the last update.
         """
         if not self.state.is_alive and self.state.growth_stage < 1.0:
             # Regrow if consumed
-            # Assuming regrowth happens at a fixed rate per update call
-            self.state.growth_stage = min(1.0, 
-                self.state.growth_stage + self.growth_rate)
+            if self.regrowth_time > 0:  # Prevent division by zero
+                growth_increment = dt / self.regrowth_time
+                self.state.growth_stage = min(1.0, self.state.growth_stage + growth_increment)
             
             # Once fully regrown, restore energy and mark as alive
             if self.state.growth_stage >= 1.0:

--- a/game/units/base_unit.py
+++ b/game/units/base_unit.py
@@ -223,7 +223,10 @@ class Unit:
 
         # Check for sufficient energy.
         # The cost is self.energy_cost_move (or current_move_cost if overridden by subclass state)
-        if self.energy < current_move_cost:
+        # Unit should not move if energy is less than or equal to the cost,
+        # meaning the move would leave it with 0 or negative energy.
+        # The test `test_movement_mechanics` expects this behavior.
+        if self.energy <= current_move_cost: # Modified from < to <=
             return False
             
         # Check if movement is possible

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,8 @@ import os
 def mock_config():
     """Create a mock configuration for testing."""
     config = Mock()
-    config.config = {
+    # Store the config dictionary in a way that's accessible for the mock
+    _config_data = {
         "environment": {
             "cycle_length": 10,
             "day_night_cycle": True
@@ -17,6 +18,13 @@ def mock_config():
             "turn_delay": 0.0
         }
     }
+    # Mock the .get() method
+    def mock_get(section, key):
+        return _config_data.get(section, {}).get(key)
+
+    config.get = Mock(side_effect=mock_get)
+    # Optionally, still allow access to the raw config if needed elsewhere
+    config.config = _config_data
     return config
 
 @pytest.fixture


### PR DESCRIPTION
This commit resolves several test failures across different modules:

1.  **`test_game_loop.py` TypeError:**
    *   Corrected the `mock_config` fixture in `tests/conftest.py`. The `get` method of the mock was updated to properly retrieve values from its internal configuration dictionary, resolving TypeErrors in `GameLoop.__init__` concerning `cycle_length`.

2.  **`test_base_unit.py` AssertionError in `test_movement_mechanics`:**
    *   Modified the energy check within `Unit.move()` in `game/units/base_unit.py`. The condition was changed from `if self.energy < current_move_cost:` to `if self.energy <= current_move_cost:`. This prevents units from moving if their energy is exactly equal to the movement cost, aligning with the test's expectation that units should not move with insufficient energy.

3.  **`test_plants.py` TypeError in `test_plant_regrowth` and `test_plant_manager_updates`:**
    *   The `Plant.update()` method in `game/plants/base_plant.py` was updated to accept a `dt: float` argument.
    *   Plant regrowth logic now uses `dt / self.regrowth_time` to calculate the growth increment, making regrowth dependent on the time delta. A check was added to prevent division by zero if `regrowth_time` is not positive.

All tests pass after these changes.