### PR TITLE
feat: Implement board visualization and unit stats printing

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,9 @@
     },
     "game": {
         "max_turns": 500,
-        "turn_delay": 0.2
+        "turn_delay": 0.2,
+        "visualization_update_frequency": 1,
+        "unit_stats_print_frequency": 5
     },
     "units": {
         "initial_count": {

--- a/game/config.py
+++ b/game/config.py
@@ -20,7 +20,9 @@ class Config:
         },
         "game": {
             "max_turns": {"type": int, "min": 1, "max": 10000},
-            "turn_delay": {"type": float, "min": 0.0, "max": 5.0}
+            "turn_delay": {"type": float, "min": 0.0, "max": 5.0},
+            "visualization_update_frequency": {"type": int, "min": 0, "max": 100},
+            "unit_stats_print_frequency": {"type": int, "min": 0, "max": 100}
         },
         "units": {
             "initial_count": {
@@ -64,7 +66,9 @@ class Config:
         },
         "game": {
             "max_turns": 1000,
-            "turn_delay": 0.1  # seconds between turns
+            "turn_delay": 0.1,  # seconds between turns
+            "visualization_update_frequency": 1,
+            "unit_stats_print_frequency": 5
         },
         "units": {
             "initial_count": {


### PR DESCRIPTION
Integrates the visualization from `game/visualization.py` into `main.py`, allowing the game board to be rendered in the terminal during gameplay.

Key changes:
- Added `Visualization` class integration in `main.py`.
- Introduced `visualization_update_frequency` config in `game/config.py` and `config.json` to control how often the board is rendered. (Default: 1, 0 to disable in-loop rendering).
- Implemented a new `print_unit_stats` function in `main.py`.
- Introduced `unit_stats_print_frequency` config in `game/config.py` and `config.json` to control how often detailed unit statistics are printed. (Default: 5, 0 to disable).
- Both features respect the `--no-display` command-line argument.
- Adjusted display logic to ensure correct timing and output.