### PR TITLE
Feature: Add 3-character UUIDs to units and fix alive/dead display logic

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -358,6 +358,7 @@ def _get_board_state_and_populate_entity_map(game_loop: GameLoop, game_id: str) 
                 entity_type = "unit"
                 name = getattr(obj, 'unit_type', type(obj).__name__)
                 details = {
+                    "uuid": getattr(obj, 'uuid', None),
                     "health": getattr(obj, 'hp', None),  # Changed from health to hp to match Unit class
                     "energy": getattr(obj, 'energy', None),
                     "state": getattr(obj, 'state', None),
@@ -419,6 +420,7 @@ class UnitStats(BaseModel):
     id: str
     type: str = "unit"
     unit_type: Optional[str] = None
+    uuid: Optional[str] = None
     x: int
     y: int
     hp: Optional[int] = None
@@ -482,6 +484,7 @@ async def get_entity_details(game_id: str, entity_id: str):
         return UnitStats(
             id=entity_id,
             unit_type=getattr(entity_obj, 'unit_type', type(entity_obj).__name__),
+            uuid=getattr(entity_obj, 'uuid', None),
             x=entity_obj.x,
             y=entity_obj.y,
             hp=getattr(entity_obj, 'hp', None),

--- a/game/units/base_unit.py
+++ b/game/units/base_unit.py
@@ -7,6 +7,13 @@ All other unit types will inherit from this base class.
 from game.board import Position
 from game.plants.base_plant import Plant # Added import
 from typing import Optional, Tuple
+import random
+import string
+
+def generate_unit_uuid() -> str:
+    """Generate a 3-character UUID for units using alphanumeric characters."""
+    characters = string.ascii_uppercase + string.digits
+    return ''.join(random.choices(characters, k=3))
 
 # Predefined unit templates for different roles
 UNIT_TEMPLATES = {
@@ -70,8 +77,9 @@ class Unit:
         self.config = config  # Store the config object
         self.board = board  # Store the board reference
 
-        # Store unit type
+        # Store unit type and generate unique UUID
         self.unit_type = unit_type
+        self.uuid = generate_unit_uuid()
 
         # Load energy costs from config or use defaults
         if config:

--- a/game/visualization.py
+++ b/game/visualization.py
@@ -239,6 +239,27 @@ class Visualization:
         
         return legend
     
+    def _format_unit_list(self) -> str:
+        """Format a list of units with their UUIDs and basic info."""
+        units_info = []
+        
+        for y in range(self.board.height):
+            for x in range(self.board.width):
+                obj = self.board.grid[y][x]
+                if isinstance(obj, Unit):
+                    uuid = getattr(obj, 'uuid', 'N/A')
+                    unit_type = getattr(obj, 'unit_type', 'Unknown')
+                    state = getattr(obj, 'state', 'Unknown')
+                    energy = getattr(obj, 'energy', 0)
+                    
+                    status = "Dead" if not getattr(obj, 'alive', True) else "Alive"
+                    units_info.append(f"[{uuid}] {unit_type} at ({x},{y}) - {state} (E:{energy}) {status}")
+        
+        if units_info:
+            return "\nUnits:\n" + "\n".join(units_info) + "\n"
+        else:
+            return "\nNo units on board\n"
+    
     def render(self) -> None:
         """
         Render the current game state to the terminal if visualization is enabled.
@@ -275,6 +296,9 @@ class Visualization:
         
         # Print legend
         print(self._format_legend())
+        
+        # Print unit list with UUIDs
+        print(self._format_unit_list())
         
         self.frame_count += 1
     

--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ def display_game(game_loop):
 
 def print_unit_stats(game_loop, current_turn):
     """Prints statistics for each unit."""
-    print(f"--- Unit Stats (Turn {current_turn}) [FIXED VERSION] ---")
+    print(f"--- Unit Stats (Turn {current_turn}) ---")
     
     # Helper function to check if unit is still on the board
     def is_unit_on_board(unit):

--- a/main.py
+++ b/main.py
@@ -93,23 +93,41 @@ def display_game(game_loop):
 
 def print_unit_stats(game_loop, current_turn):
     """Prints statistics for each unit."""
-    print(f"--- Unit Stats (Turn {current_turn}) ---")
+    print(f"--- Unit Stats (Turn {current_turn}) [FIXED VERSION] ---")
     
-    # First print alive units
-    alive_units = [unit for unit in game_loop.units if unit.alive]
+    # Helper function to check if unit is still on the board
+    def is_unit_on_board(unit):
+        if not game_loop.board.is_valid_position(unit.x, unit.y):
+            return False
+        return game_loop.board.grid[unit.y][unit.x] == unit
+    
+    # Get units that are still relevant to the game (alive or still on board)
+    relevant_units = [unit for unit in game_loop.units if unit.alive or is_unit_on_board(unit)]
+    
+    # Categorize relevant units
+    alive_units = [unit for unit in relevant_units if unit.alive]
+    dead_units = [unit for unit in relevant_units if not unit.alive]
+    
     if alive_units:
         print("\nAlive Units:")
         for unit in alive_units:
-            print(f"  - Type: {unit.unit_type}, Pos: ({unit.x}, {unit.y}), "
+            print(f"  - [{unit.uuid}] Type: {unit.unit_type}, Pos: ({unit.x}, {unit.y}), "
                   f"Energy: {unit.energy}, State: {unit.state}")
     
-    # Then print dead units
-    dead_units = [unit for unit in game_loop.units if not unit.alive]
     if dead_units:
-        print("\nDead Units:")
+        print("\nDead Units (still on board):")
         for unit in dead_units:
-            print(f"  - Type: {unit.unit_type}, Pos: ({unit.x}, {unit.y}), "
-                  f"State: {unit.state}")
+            decay_info = f", Decay: {getattr(unit, 'decay_stage', 'N/A')}" if hasattr(unit, 'decay_stage') else ""
+            print(f"  - [{unit.uuid}] Type: {unit.unit_type}, Pos: ({unit.x}, {unit.y}), "
+                  f"State: {unit.state}{decay_info}")
+    
+    # Show total counts for clarity
+    total_in_game = len(game_loop.units)
+    total_shown = len(relevant_units)
+    fully_decayed = total_in_game - total_shown
+    
+    if fully_decayed > 0:
+        print(f"\nNote: {fully_decayed} fully decayed unit(s) not shown (removed from board)")
     
     print(f"\n--- End Unit Stats ---")
     if sys.stdin.isatty(): # Check if running in an interactive terminal


### PR DESCRIPTION
**Unit UUID System:**
- Add generate_unit_uuid() function creating 3-character alphanumeric IDs
- Integrate UUID generation into base Unit class constructor
- Each unit now has unique identifier for tracking (e.g. "B2G", "VDN", "T2F")

**Terminal Display Updates:**
- Update main.py unit stats to show UUIDs: [UUID] Type: predator, Pos: (x,y)...
- Add UUID display to both alive and dead unit listings
- Fix alive/dead unit categorization logic to match board reality

**Web UI Integration:**
- Add uuid field to API unit details and UnitStats model
- UUID now included in both board entity lists and detailed stats
- Web interface displays unit UUIDs alongside other unit information

**Visualization Enhancement:**
- Add _format_unit_list() method showing units with UUIDs
- Terminal visualization displays unit list after game board
- Format: [UUID] unit_type at (x,y) - state (E:energy) Status

**Critical Bug Fix - Alive/Dead Display Logic:**
- Fix discrepancy where unit stats showed more units than board display
- Issue: Dead units remained in game_loop.units forever, even after board removal
- Solution: Only show "relevant units" (alive OR still on board decaying)
- Add decay stage info and note about fully decayed hidden units

**Results:**
- Consistent unit counts between board visualization and stats printout
- Easy unit tracking with unique 3-character identifiers
- Clear distinction between alive, dead-decaying, and fully-decayed units
- Improved debugging and unit identification across all interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)